### PR TITLE
Update README for HololiveCardApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,97 +1,81 @@
-This is a new [**React Native**](https://reactnative.dev) project, bootstrapped using [`@react-native-community/cli`](https://github.com/react-native-community/cli).
+# HololiveCardApp
 
-# Getting Started
+HololiveCardApp is a React Native project built with TypeScript. The goal of the
+application is to experiment with mobile interfaces for browsing and managing
+Hololive themed trading cards. The project was generated using the
+`@react-native-community/cli` tool and follows the standard React Native project
+structure.
 
-> **Note**: Make sure you have completed the [Set Up Your Environment](https://reactnative.dev/docs/set-up-your-environment) guide before proceeding.
+## Prerequisites
 
-## Step 1: Start Metro
+- **Node.js** 18 or later
+- **npm** or **Yarn** for managing packages
+- **Android Studio** or an Android device for Android builds
+- **Xcode** with Ruby and Bundler for installing CocoaPods when building for iOS
 
-First, you will need to run **Metro**, the JavaScript build tool for React Native.
+Follow the [React Native environment setup guide](https://reactnative.dev/docs/environment-setup)
+to configure your system.
 
-To start the Metro dev server, run the following command from the root of your React Native project:
+## Setup
+
+1. Install JavaScript dependencies:
+
+   ```sh
+   npm install
+   # or
+   yarn install
+   ```
+
+2. Start the Metro bundler:
+
+   ```sh
+   npm start
+   # or
+   yarn start
+   ```
+
+3. Build and run the application:
+
+   - **Android**
+
+     ```sh
+     npm run android
+     # or
+     yarn android
+     ```
+
+   - **iOS** (after installing CocoaPods dependencies)
+
+     ```sh
+     bundle install
+     bundle exec pod install
+     npm run ios
+     # or
+     yarn ios
+     ```
+
+## Development Guidelines
+
+- Source code is written in TypeScript and linted with ESLint. Run
+  `npm run lint` (or `yarn lint`) before committing code.
+- Code formatting is handled by Prettier (configuration in `.prettierrc.js`).
+- Keep changes small and well described in commit messages.
+
+## Running Tests
+
+Unit tests use [Jest](https://jestjs.io/). Execute the full test suite with:
 
 ```sh
-# Using npm
-npm start
-
-# OR using Yarn
-yarn start
+npm test
+# or
+yarn test
 ```
 
-## Step 2: Build and run your app
+Test files live in the `__tests__` directory and follow the `*.test.tsx` naming
+convention.
 
-With Metro running, open a new terminal window/pane from the root of your React Native project, and use one of the following commands to build and run your Android or iOS app:
+---
 
-### Android
-
-```sh
-# Using npm
-npm run android
-
-# OR using Yarn
-yarn android
-```
-
-### iOS
-
-For iOS, remember to install CocoaPods dependencies (this only needs to be run on first clone or after updating native deps).
-
-The first time you create a new project, run the Ruby bundler to install CocoaPods itself:
-
-```sh
-bundle install
-```
-
-Then, and every time you update your native dependencies, run:
-
-```sh
-bundle exec pod install
-```
-
-For more information, please visit [CocoaPods Getting Started guide](https://guides.cocoapods.org/using/getting-started.html).
-
-```sh
-# Using npm
-npm run ios
-
-# OR using Yarn
-yarn ios
-```
-
-If everything is set up correctly, you should see your new app running in the Android Emulator, iOS Simulator, or your connected device.
-
-This is one way to run your app — you can also build it directly from Android Studio or Xcode.
-
-## Step 3: Modify your app
-
-Now that you have successfully run the app, let's make changes!
-
-Open `App.tsx` in your text editor of choice and make some changes. When you save, your app will automatically update and reflect these changes — this is powered by [Fast Refresh](https://reactnative.dev/docs/fast-refresh).
-
-When you want to forcefully reload, for example to reset the state of your app, you can perform a full reload:
-
-- **Android**: Press the <kbd>R</kbd> key twice or select **"Reload"** from the **Dev Menu**, accessed via <kbd>Ctrl</kbd> + <kbd>M</kbd> (Windows/Linux) or <kbd>Cmd ⌘</kbd> + <kbd>M</kbd> (macOS).
-- **iOS**: Press <kbd>R</kbd> in iOS Simulator.
-
-## Congratulations! :tada:
-
-You've successfully run and modified your React Native App. :partying_face:
-
-### Now what?
-
-- If you want to add this new React Native code to an existing application, check out the [Integration guide](https://reactnative.dev/docs/integration-with-existing-apps).
-- If you're curious to learn more about React Native, check out the [docs](https://reactnative.dev/docs/getting-started).
-
-# Troubleshooting
-
-If you're having issues getting the above steps to work, see the [Troubleshooting](https://reactnative.dev/docs/troubleshooting) page.
-
-# Learn More
-
-To learn more about React Native, take a look at the following resources:
-
-- [React Native Website](https://reactnative.dev) - learn more about React Native.
-- [Getting Started](https://reactnative.dev/docs/environment-setup) - an **overview** of React Native and how setup your environment.
-- [Learn the Basics](https://reactnative.dev/docs/getting-started) - a **guided tour** of the React Native **basics**.
-- [Blog](https://reactnative.dev/blog) - read the latest official React Native **Blog** posts.
-- [`@facebook/react-native`](https://github.com/facebook/react-native) - the Open Source; GitHub **repository** for React Native.
+With the prerequisites installed, you can run the app on a simulator or device
+using the commands above. Feel free to modify `App.tsx` and use this project as a
+starting point for your own Hololive trading card ideas.


### PR DESCRIPTION
## Summary
- rewrite README with HololiveCardApp description
- add setup, prerequisites, dev guidelines and test instructions

## Testing
- `npm install` *(fails: Exit handler never called)*