### PR TITLE
Add Express API server and data service

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,16 @@ convention.
 With the prerequisites installed, you can run the app on a simulator or device
 using the commands above. Feel free to modify `App.tsx` and use this project as a
 starting point for your own Hololive trading card ideas.
+
+## API Server
+
+This repository now includes a lightweight Express server in `hololive-api`.
+Start it in development mode with:
+
+```sh
+cd hololive-api
+npm install
+npm run dev
+```
+
+The API exposes tournament data and statistics used by the mobile app.

--- a/hololive-api/.gitignore
+++ b/hololive-api/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/hololive-api/controllers/holomemController.js
+++ b/hololive-api/controllers/holomemController.js
@@ -1,0 +1,80 @@
+const {
+  tournamentData,
+  preCalculatedData,
+  holomemDetailsData
+} = require('../data/mockData');
+
+// 全トーナメントデータを取得
+exports.getAllTournaments = (req, res) => {
+  const { region, eventType, holomem } = req.query;
+
+  let filteredData = [...tournamentData];
+
+  if (region) {
+    filteredData = filteredData.filter(t => t.region === region);
+  }
+
+  if (eventType) {
+    filteredData = filteredData.filter(t => t.eventType === eventType);
+  }
+
+  if (holomem) {
+    filteredData = filteredData.filter(t => t.mainHolomem === holomem);
+  }
+
+  res.json(filteredData);
+};
+
+// IDでトーナメントを取得
+exports.getTournamentById = (req, res) => {
+  const tournament = tournamentData.find(t => t.id === req.params.id);
+
+  if (!tournament) {
+    return res.status(404).json({ message: 'Tournament not found' });
+  }
+
+  res.json(tournament);
+};
+
+// 期間ごとの統計データを取得
+exports.getStatsByPeriod = (req, res) => {
+  const { period } = req.params;
+
+  if (!['daily', 'weekly', 'monthly', 'yearly'].includes(period)) {
+    return res.status(400).json({ message: 'Invalid period. Use daily, weekly, monthly, or yearly' });
+  }
+
+  const data = preCalculatedData[period];
+
+  if (!data) {
+    return res.status(404).json({ message: 'Data not found for this period' });
+  }
+
+  res.json(data);
+};
+
+// ホロメンの詳細情報を取得
+exports.getHolomemDetails = (req, res) => {
+  const { name } = req.params;
+
+  const holomem = holomemDetailsData[name];
+
+  if (!holomem) {
+    return res.status(404).json({ message: 'Holomem details not found' });
+  }
+
+  res.json({
+    name,
+    ...holomem
+  });
+};
+
+// 全ての統計情報を取得
+exports.getAllStats = (_req, res) => {
+  res.json({
+    daily: preCalculatedData.daily,
+    weekly: preCalculatedData.weekly,
+    monthly: preCalculatedData.monthly,
+    yearly: preCalculatedData.yearly
+  });
+};

--- a/hololive-api/data/mockData.js
+++ b/hololive-api/data/mockData.js
@@ -1,0 +1,158 @@
+// ホロメンカラーコード
+const holomemColors = {
+  'ときのそら': '#0146EA',
+  'ロボ子さん': '#804E7F',
+  'さくらみこ': '#FE4B74',
+  '星街すいせい': '#2dcde4',
+  'AZKi': '#d11c76',
+  '夜空メル': '#ffc004',
+  'アキ・ローゼンタール': '#dc0485',
+  '赤井はあと': '#d9062a',
+  '白上フブキ': '#53c7ea',
+  '夏色まつり': '#ff5606',
+  '湊あくあ': '#fe5dd8',
+  '紫咲シオン': '#8a54cb',
+  '百鬼あやめ': '#ca223a',
+  '癒月ちょこ': '#dc5686',
+  '大空スバル': '#bde717',
+  '大神ミオ': '#dc1935',
+  '猫又おかゆ': '#bf65e8',
+  '戌神ころね': '#dcb414',
+  '兎田ぺこら': '#65baea',
+  '潤羽るしあ': '#0de1bd',
+  '不知火フレア': '#dc3813',
+  '白銀ノエル': '#89939d',
+  '宝鐘マリン': '#a72413',
+  '天音かなた': '#76c0ea',
+  '桐生ココ': '#db7311',
+  '角巻わため': '#dbda89',
+  '常闇トワ': '#a7a2ea',
+  '姫森ルーナ': '#db6cad',
+  '雪花ラミィ': '#48b5e3',
+  '桃鈴ねね': '#fe7a0f',
+  '獅白ぼたん': '#5fcfa6',
+  '尾丸ポルカ': '#ab0808',
+  'ラプラス・ダークネス': '#441495',
+  '鷹嶺ルイ': '#28040d',
+  '博衣こより': '#fe68ad',
+  '沙花叉クロヱ': '#ab0e0c',
+  '風真いろは': '#44bfb7'
+};
+
+// 大会データ
+const tournamentData = [
+  {
+    id: '1',
+    url: 'https://x.com/HBSTkawasaki/status/1897934921941008648',
+    deckName: 'かなた単',
+    region: '神奈川',
+    participants: 26,
+    eventType: 'エクストリーマーカップ',
+    mainHolomem: '天音かなた',
+    hasWon: true,
+    date: '2025-03-05'
+  },
+  {
+    id: '2',
+    url: 'https://x.com/HBSTkawasaki/status/1897934921941008648',
+    deckName: 'レイネイオフィ',
+    region: '神奈川',
+    participants: 25,
+    eventType: 'エクストリーマーカップ',
+    mainHolomem: '',
+    hasWon: false,
+    date: '2025-03-05'
+  },
+  // 他のデータは省略
+];
+
+// 事前計算されたデータ
+const preCalculatedData = {
+  daily: {
+    startDate: '2025-03-06',
+    endDate: '2025-03-07',
+    totalTournaments: 5,
+    usageData: [
+      { name: '天音かなた', usage: 35, count: 3, color: '#76c0ea' },
+      { name: '白上フブキ', usage: 30, count: 3, color: '#53c7ea' },
+      { name: 'さくらみこ', usage: 20, count: 2, color: '#FE4B74' },
+      { name: '戌神ころね', usage: 15, count: 1, color: '#dcb414' },
+      { name: '兎田ぺこら', usage: 10, count: 1, color: '#65baea' },
+      // その他のデータ
+    ],
+    eventTypeData: {
+      'エクストリーマーカップ': 2,
+      'ショップ大会': 2,
+      '交流会': 1
+    },
+    regionData: {
+      '関東': 3,
+      '関西': 1,
+      '九州': 1
+    }
+  },
+  weekly: {
+    startDate: '2025-03-01',
+    endDate: '2025-03-07',
+    totalTournaments: 12,
+    usageData: [
+      { name: '天音かなた', usage: 30, count: 4, color: '#76c0ea' },
+      { name: '白上フブキ', usage: 25, count: 3, color: '#53c7ea' },
+      { name: 'さくらみこ', usage: 20, count: 2, color: '#FE4B74' },
+      { name: '戌神ころね', usage: 15, count: 2, color: '#dcb414' },
+      { name: '兎田ぺこら', usage: 10, count: 1, color: '#65baea' },
+      // その他のデータ
+    ],
+    eventTypeData: {
+      'エクストリーマーカップ': 5,
+      'ショップ大会': 4,
+      '交流会': 3
+    },
+    regionData: {
+      '関東': 5,
+      '関西': 3,
+      '九州': 2,
+      '中部': 1,
+      '北海道': 1
+    }
+  },
+  // monthly, yearlyも同様に
+};
+
+// ホロメン詳細データ
+const holomemDetailsData = {
+  '天音かなた': {
+    regions: [
+      { region: '関東', rank: 1, percentage: 42 },
+      { region: '関西', rank: 2, percentage: 35 },
+      { region: '九州', rank: 3, percentage: 28 },
+    ],
+    trends: { weeklyChange: 5, monthlyChange: -2 },
+    eventTypes: [
+      { name: 'エクストリーマーカップ', value: 40 },
+      { name: 'ショップ大会', value: 32 },
+      { name: '交流会', value: 28 },
+    ]
+  },
+  '白上フブキ': {
+    regions: [
+      { region: '関東', rank: 2, percentage: 38 },
+      { region: '北海道', rank: 1, percentage: 40 },
+      { region: '東北', rank: 2, percentage: 31 },
+    ],
+    trends: { weeklyChange: -3, monthlyChange: 4 },
+    eventTypes: [
+      { name: 'エクストリーマーカップ', value: 35 },
+      { name: 'ショップ大会', value: 38 },
+      { name: '交流会', value: 27 },
+    ]
+  },
+  // 他のホロメンも同様に
+};
+
+module.exports = {
+  holomemColors,
+  tournamentData,
+  preCalculatedData,
+  holomemDetailsData
+};

--- a/hololive-api/package.json
+++ b/hololive-api/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "hololive-api",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.0.0",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.0"
+  }
+}

--- a/hololive-api/routes/api.js
+++ b/hololive-api/routes/api.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+const holomemController = require('../controllers/holomemController');
+
+// トーナメントデータ取得
+router.get('/tournaments', holomemController.getAllTournaments);
+router.get('/tournaments/:id', holomemController.getTournamentById);
+
+// 分析データ取得
+router.get('/stats/:period', holomemController.getStatsByPeriod);
+router.get('/holomem/:name', holomemController.getHolomemDetails);
+
+// 全期間の統計情報
+router.get('/stats', holomemController.getAllStats);
+
+module.exports = router;

--- a/hololive-api/server.js
+++ b/hololive-api/server.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const cors = require('cors');
+require('dotenv').config();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// ミドルウェア
+app.use(cors());
+app.use(express.json());
+
+// ルート
+const apiRoutes = require('./routes/api');
+app.use('/api', apiRoutes);
+
+// 基本ルート
+app.get('/', (req, res) => {
+  res.json({ message: 'Welcome to Hololive Card Game API' });
+});
+
+// サーバー起動
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+});

--- a/src/data/defaultData.js
+++ b/src/data/defaultData.js
@@ -1,0 +1,12 @@
+export const defaultTournamentData = [
+  {
+    id: 'default1',
+    deckName: 'Sample Deck',
+    region: 'Unknown',
+    participants: 0,
+    eventType: 'Unknown',
+    mainHolomem: '',
+    hasWon: false,
+    date: '1970-01-01'
+  }
+];

--- a/src/services/dataService.js
+++ b/src/services/dataService.js
@@ -1,0 +1,92 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { defaultTournamentData } from '../data/defaultData';
+
+// APIのベースURL
+const API_BASE_URL = 'http://localhost:3000/api';
+
+export const useTournamentData = () => {
+  const [data, setData] = useState(defaultTournamentData);
+  const [stats, setStats] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [lastUpdated, setLastUpdated] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        // 大会データを取得
+        const tournamentsResponse = await axios.get(`${API_BASE_URL}/tournaments`);
+        setData(tournamentsResponse.data);
+
+        // 統計データも取得
+        const statsResponse = await axios.get(`${API_BASE_URL}/stats`);
+        setStats(statsResponse.data);
+
+        setLastUpdated(new Date());
+      } catch (error) {
+        console.log('APIデータ取得エラー、デフォルトデータを使用します', error);
+        setError(error);
+        // デフォルトデータはすでに設定済み
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  // データを手動で更新する関数
+  const refreshData = async () => {
+    setLoading(true);
+    try {
+      const tournamentsResponse = await axios.get(`${API_BASE_URL}/tournaments`);
+      setData(tournamentsResponse.data);
+
+      const statsResponse = await axios.get(`${API_BASE_URL}/stats`);
+      setStats(statsResponse.data);
+
+      setLastUpdated(new Date());
+      setError(null);
+    } catch (error) {
+      console.log('データ更新エラー', error);
+      setError(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 特定のホロメンの詳細データを取得
+  const getHolomemDetails = async (name) => {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/holomem/${name}`);
+      return response.data;
+    } catch (error) {
+      console.error('ホロメン詳細取得エラー', error);
+      return null;
+    }
+  };
+
+  // 特定の期間の統計データを取得
+  const getStatsByPeriod = async (period) => {
+    if (stats[period]) return stats[period];
+
+    try {
+      const response = await axios.get(`${API_BASE_URL}/stats/${period}`);
+      return response.data;
+    } catch (error) {
+      console.error('統計データ取得エラー', error);
+      return null;
+    }
+  };
+
+  return {
+    data,
+    loading,
+    error,
+    lastUpdated,
+    refreshData,
+    getHolomemDetails,
+    getStatsByPeriod
+  };
+};


### PR DESCRIPTION
## Summary
- add `hololive-api` Express server with mock tournament data
- provide new React service `useTournamentData`
- document how to run the API server

## Testing
- `npm test` *(fails: jest not found)*